### PR TITLE
Fix arithmetic operators and code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Dave
 Python does not use begin and end tags to group lines of code into functions, loops or if-statements. It uses white space indentation only and this is rigidly enforced. Compare the two code samples below:
 
 - Visual Basic:
+
 ```vb
 Dim count As Integer
 count = 1
@@ -108,7 +109,9 @@ If count > 0 Then
     MsgBox "Hello"
 End If
 ```
+
 - Python:
+
 ```python
 count = 1
 
@@ -191,8 +194,9 @@ Operator | Visual Basic | Python
 --- | --- | ---
 Add | `c = a + b` | `c = a + b`
 Subtract | `c = a - b` | `c = a - b`
-Multiply | `c = a - b` | `c = a - b`
-Divide | `c = a / b` | `c = a / b`<br/>`c = a // b # Floor`
+Multiply | `c = a * b` | `c = a * b`
+Divide (true) | `c = a / b` | `c = a / b`
+Divide (floor) | `c = a \ b` | `c = a // b`
 Modulus division | `c = a Mod b`  | `c = a % b`
 Exponent | `c = a ^ b` |  `c = a *- b`
 


### PR DESCRIPTION
Indentation and spacing causing some code examples to render incorrectly on the main site (although not on GH). Also corrected multiplication operator in the arithmetic operators table, and added the VB integer division operator as the equivalent for Python's floor division operator.

I was tempted to alter usage of MsgBox to Debug.Print (which is closer to Python's print statement/function) but I suspect most VB users don't know about the global Debug object and just put up with MsgBox and endless clicking on Ok...
